### PR TITLE
Graph sizing

### DIFF
--- a/src/components/graph-container.js
+++ b/src/components/graph-container.js
@@ -6,7 +6,13 @@ import { reRenderGraph } from '../actions/createAdventure'
 
 
 class GraphContainer extends React.Component {
-
+    constructor(props){
+        super(props);
+        this.state = {
+          windowHeight: window.innerHeight,
+          windowWidth: window.innerWidth
+        };
+    }
     onClickNode(nodeId) {
         let nodeArr = this.props.nodez.filter((node) => node.id === nodeId)
         this.props.dispatch(setCurrentNode(nodeArr[0]))
@@ -27,7 +33,7 @@ class GraphContainer extends React.Component {
         };
         for (let i = 0; i < this.props.nodez.length; i++) {
             if (i === 0) {
-                chartData.nodes.push({ id: this.props.nodez[i].id, title: this.props.nodez[i].title ? this.props.nodez[i].title : this.props.nodez[i].question, color: 'red', symbolType: "triangle" })
+                chartData.nodes.push({ id: this.props.nodez[i].id, title: this.props.nodez[i].title ? this.props.nodez[i].title : this.props.nodez[i].question, color: '#da8624', symbolType: "triangle" })
                 if (this.props.nodez[i].pointerA) {
                     chartData.links.push({ source: this.props.nodez[i].id, target: this.props.nodez[i].pointerA })
                 }
@@ -41,7 +47,7 @@ class GraphContainer extends React.Component {
                     chartData.links.push({ source: this.props.nodez[i].id, target: this.props.nodez[i].pointerD })
                 }
             } else {
-                chartData.nodes.push({ id: this.props.nodez[i].id, title: this.props.nodez[i].title ? this.props.nodez[i].title : this.props.nodez[i].question, color: this.props.nodez[i].ending ? 'blue' : 'lightgreen', symbolType: this.props.nodez[i].ending ? "square" : "circle"})
+                chartData.nodes.push({ id: this.props.nodez[i].id, title: this.props.nodez[i].title ? this.props.nodez[i].title : this.props.nodez[i].question, color: this.props.nodez[i].ending ? '#51646b' : '#b4cedd', symbolType: this.props.nodez[i].ending ? "square" : "circle"})
                 if (this.props.nodez[i].pointerA) {
                     chartData.links.push({ source: this.props.nodez[i].id, target: this.props.nodez[i].pointerA })
                 }
@@ -59,8 +65,41 @@ class GraphContainer extends React.Component {
         return chartData;
     }
 
+    resizeGraph(){
+        console.log('resizeGraph ran!');
+        let cyStyle = {
+            margin: 'auto',
+            border: '1px solid lightgreen'
+        }
+        cyStyle.maxHeight = Math.max(this.state.windowHeight * .5, 500);
+        cyStyle.maxWidth = Math.max(this.state.windowWidth * .8, 300);
+
+        console.log(cyStyle.maxHeight = Math.max(this.state.windowHeight * .5, 500));
+        console.log(cyStyle.maxWidth = Math.max(this.state.windowWidth * .8, 300));
+        return cyStyle;
+    }
+
+    handleResize = e => {
+        console.log('handleResize ran!');
+        let windowHeight = window.innerHeight;
+        let windowWidth = window.innerWidth;
+        this.setState({
+            windowHeight,
+            windowWidth
+        })
+    }
+
+    componentDidMount(){
+      window.addEventListener("resize", this.handleResize);
+    }
+
     componentWillMount() {
-       this.populateGraph()
+       this.populateGraph();
+       this.resizeGraph();
+    }
+
+    componentWillUnmount(){
+        window.removeEventListener("resize", this.handleResize);
     }
 
     render() {
@@ -70,14 +109,14 @@ class GraphContainer extends React.Component {
             automaticRearrangeAfterDropNode: true,
             d3: {
                 gravity: -300,
-                linkLength: 200,
+                linkLength: 120,
                 forceManyBody: function strength() {
                     return -1000;
                 },
             },
             minZoom: .5,
             maxZoom: 1.5,
-          
+            //There are height and widths available here, but they're for the graph itself, not the container of the graph
             node: {
                 fontSize: 18,
                 color: 'lightgreen',
@@ -91,18 +130,14 @@ class GraphContainer extends React.Component {
                 strokeWidth: 4
             }
         };
-        const cyStyle = {
-            margin: 'auto',
-            border: '1px solid lightgreen'
-        };
         if (!this.props.nodez) {
             return <div>Loading....</div>
         } else {
             if (this.props.reRender) {
                 return (
-                    <div style={cyStyle}>
+                <div style={this.resizeGraph()}> {/*Make the cyStyle into a method like populateGraph for CSS RESPONSIVENESS*/}
                         <Graph
-                            props={this.props}
+                            props={this.props} 
                             id="graph-id" // id is mandatory, if no id is defined rd3g will throw an error
                             data={this.populateGraph()}
                             config={myConfig}
@@ -120,7 +155,7 @@ class GraphContainer extends React.Component {
                 );
             } else {
                 return (
-                    <div style={cyStyle}>
+                    <div style={this.resizeGraph()}>
                         <Graph
                             props={this.props}
                             id="graph-id" // id is mandatory, if no id is defined rd3g will throw an error

--- a/src/components/graph-container.js
+++ b/src/components/graph-container.js
@@ -66,21 +66,17 @@ class GraphContainer extends React.Component {
     }
 
     resizeGraph(){
-        console.log('resizeGraph ran!');
         let cyStyle = {
             margin: 'auto',
             border: '1px solid lightgreen'
-        }
+        };
         cyStyle.maxHeight = Math.max(this.state.windowHeight * .5, 500);
         cyStyle.maxWidth = Math.max(this.state.windowWidth * .8, 300);
-
-        console.log(cyStyle.maxHeight = Math.max(this.state.windowHeight * .5, 500));
-        console.log(cyStyle.maxWidth = Math.max(this.state.windowWidth * .8, 300));
         return cyStyle;
     }
 
-    handleResize = e => {
-        console.log('handleResize ran!');
+    //if you change this from an arrow function, this.setState fails
+    handleResize = () => {
         let windowHeight = window.innerHeight;
         let windowWidth = window.innerWidth;
         this.setState({
@@ -116,6 +112,8 @@ class GraphContainer extends React.Component {
             },
             minZoom: .5,
             maxZoom: 1.5,
+            height: Math.max(this.state.windowHeight * .5, 500),
+            width: Math.max(this.state.windowWidth * .8, 300),
             //There are height and widths available here, but they're for the graph itself, not the container of the graph
             node: {
                 fontSize: 18,

--- a/src/components/graph-container.js
+++ b/src/components/graph-container.js
@@ -62,6 +62,8 @@ class GraphContainer extends React.Component {
                 }
             }
         }
+        chartData.nodes[0].x = this.state.windowWidth;
+        chartData.nodes[0].y = this.state.windowHeight;
         return chartData;
     }
 


### PR DESCRIPTION
Added a state to graph-container for window Height and Width. Also added eventlisteners for window resizing so the graph now automatically rerenders and resizes when the window size changes. It does not currently center. Color for the headnode was recolored to orange, normal checkpoints are a mediumish blue-gray and the endings are dark-blue grey.

Graph Container now does not display graph components outside of the graph. Resizes both the container and the graph itself automatically upon window resize. Would like to test this on a phone rather than the web console as there seems to be something funky about the dev tool device bar.

Several attempts to get the headnode to play nice have failed but at least it still resizes!

Merge branch 'develop' into graphSizing