### PR TITLE
Graph head node fix

### DIFF
--- a/src/components/graph-container.js
+++ b/src/components/graph-container.js
@@ -66,8 +66,8 @@ class GraphContainer extends React.Component {
                 }
             }
         }
-        chartData.nodes[0].x = this.state.windowWidth;
-        chartData.nodes[0].y = this.state.windowHeight;
+        chartData.nodes[0].x = this.state.windowWidth / 2;
+        chartData.nodes[0].y = this.state.windowHeight / 2;
         return chartData;
     }
 


### PR DESCRIPTION
Added a / 2 to the chartData.nodes[0].x/y equations in order to ensure that the head node appears.